### PR TITLE
mysqlのDockerfileにmy.cnfに対してchmodを行う行を追加した

### DIFF
--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -4,6 +4,8 @@ ADD ./my.cnf /etc/mysql/conf.d/my.cnf
 ADD ./hosts /etc/hosts
 
 RUN ln -sf  /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
+RUN chmod 600 /etc/mysql/conf.d/my.cnf
+
 EXPOSE 33060
 EXPOSE 3306
 CMD [ "mysqld" ]

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -3,8 +3,8 @@ FROM mysql
 ADD ./my.cnf /etc/mysql/conf.d/my.cnf
 ADD ./hosts /etc/hosts
 
-RUN ln -sf  /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
-RUN chmod 600 /etc/mysql/conf.d/my.cnf
+RUN ln -sf  /usr/share/zoneinfo/Asia/Tokyo /etc/localtime &&\
+    chmod 600 /etc/mysql/conf.d/my.cnf
 
 EXPOSE 33060
 EXPOSE 3306

--- a/docker/mysql/db/init.sql
+++ b/docker/mysql/db/init.sql
@@ -1,3 +1,6 @@
+SET CHARSET UTF8;
+CREATE DATABASE IF NOT EXISTS pre_app_db DEFAULT CHARACTER SET utf8;
+
 use pre_app_db;
 
 create table users(


### PR DESCRIPTION
名前の通りです。
これでWSL2上でも最初からutf-8になった筈なのですが、それでも最初から文字化けが発生してしまいます。（動作的に、他の文字コードからutf-8に無理やり変換しているという状態になっているようです。init.sqlが読み込まれる前にmy.cnfを読み込ませることができれば多分うまくいくと思うのですが…）

余談ですが、commitするアカウントを間違えました。